### PR TITLE
Bump to kooper v0.6.0-fork-0.1.0 which fixes handler panic on error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -358,7 +358,7 @@
   version = "v1.4.1"
 
 [[projects]]
-  digest = "1:e25d5e3d9a88cad6bfa093dcde691d726bd48caeed83498198a687a7bdb64b65"
+  digest = "1:a1cf05ea64d6e421c4a51dbd0c71f273d04a515cea3e1b75ce5b3abd36dfb5f2"
   name = "github.com/snebel29/kooper"
   packages = [
     "log",
@@ -370,8 +370,8 @@
     "operator/retrieve",
   ]
   pruneopts = "UT"
-  revision = "7b7db0d3c027597aa6c7316a44e69f5dceed08ac"
-  version = "v0.5.1-fork"
+  revision = "afd18a1e9ef195c3dce5cb5435556553728a9122"
+  version = "v0.6.0-fork-0.1.0"
 
 [[projects]]
   digest = "1:c1b1102241e7f645bc8e0c22ae352e8f0dc6484b6cb4d132fa9f24174e0119e2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/snebel29/kooper"
-  version = "v0.5.1-fork"
+  version = "v0.6.0-fork-0.1.0"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"

--- a/vendor/github.com/snebel29/kooper/log/log.go
+++ b/vendor/github.com/snebel29/kooper/log/log.go
@@ -3,8 +3,6 @@ package log
 import (
 	"fmt"
 	"log"
-
-	"github.com/golang/glog"
 )
 
 // Logger is the interface that the loggers used by the library will use.
@@ -22,19 +20,6 @@ type dummy struct{}
 func (d *dummy) Infof(format string, args ...interface{})    {}
 func (d *dummy) Warningf(format string, args ...interface{}) {}
 func (d *dummy) Errorf(format string, args ...interface{})   {}
-
-// Glog is a wrapper for glog logger.
-type Glog struct{}
-
-func (g *Glog) Infof(format string, args ...interface{}) {
-	glog.Infof(format, args...)
-}
-func (g *Glog) Warningf(format string, args ...interface{}) {
-	glog.Warningf(format, args...)
-}
-func (g *Glog) Errorf(format string, args ...interface{}) {
-	glog.Errorf(format, args...)
-}
 
 // Std is a wrapper for go standard library logger.
 type Std struct{}

--- a/vendor/github.com/snebel29/kooper/operator/controller/generic.go
+++ b/vendor/github.com/snebel29/kooper/operator/controller/generic.go
@@ -250,17 +250,17 @@ func (g *generic) getAndProcessNextJob() bool {
 
 	// Process the job. If errors then enqueue again.
 	if err := g.processJob(ctx, evt); err == nil {
-		g.queue.Forget(evt.Key)
+		g.queue.Forget(evt)
 		g.setForgetSpanInfo(evt.Key, span, err)
-	} else if g.queue.NumRequeues(evt.Key) < g.cfg.ProcessingJobRetries {
+	} else if g.queue.NumRequeues(evt) < g.cfg.ProcessingJobRetries {
 		// Job processing failed, requeue.
 		g.logger.Warningf("error processing %s job (requeued): %v", evt.Key, err)
-		g.queue.AddRateLimited(evt.Key)
+		g.queue.AddRateLimited(evt)
 		g.metrics.IncResourceEventQueued(g.cfg.Name, metrics.RequeueEvent)
 		g.setReenqueueSpanInfo(evt.Key, span, err)
 	} else {
 		g.logger.Errorf("Error processing %s: %v", evt.Key, err)
-		g.queue.Forget(evt.Key)
+		g.queue.Forget(evt)
 		g.setForgetSpanInfo(evt.Key, span, err)
 	}
 


### PR DESCRIPTION
Fix for https://github.com/snebel29/kwatchman/issues/18 now handlers can safely return errors, and retries will be handled by kooper using its retry policy (default to: 3 before removing from queue)